### PR TITLE
btrfs: restore mount option info messages during mount / btrfs: Align log messages and fix duplicates for NODATACOW/NODATASUM

### DIFF
--- a/fs/btrfs/super.c
+++ b/fs/btrfs/super.c
@@ -88,6 +88,9 @@ struct btrfs_fs_context {
 	refcount_t refs;
 };
 
+static void btrfs_emit_options(struct btrfs_fs_info *info,
+			       struct btrfs_fs_context *old);
+
 enum {
 	Opt_acl,
 	Opt_clear_cache,
@@ -689,12 +692,9 @@ bool btrfs_check_options(const struct btrfs_fs_info *info,
 
 	if (!test_bit(BTRFS_FS_STATE_REMOUNTING, &info->fs_state)) {
 		if (btrfs_raw_test_opt(*mount_opt, SPACE_CACHE)) {
-			btrfs_info(info, "disk space caching is enabled");
 			btrfs_warn(info,
 "space cache v1 is being deprecated and will be removed in a future release, please use -o space_cache=v2");
 		}
-		if (btrfs_raw_test_opt(*mount_opt, FREE_SPACE_TREE))
-			btrfs_info(info, "using free-space-tree");
 	}
 
 	return ret;
@@ -970,6 +970,8 @@ static int btrfs_fill_super(struct super_block *sb,
 		btrfs_err(fs_info, "open_ctree failed: %d", err);
 		return err;
 	}
+
+	btrfs_emit_options(fs_info, NULL);
 
 	inode = btrfs_iget(BTRFS_FIRST_FREE_OBJECTID, fs_info->fs_root);
 	if (IS_ERR(inode)) {

--- a/fs/btrfs/super.c
+++ b/fs/btrfs/super.c
@@ -1430,7 +1430,7 @@ static void btrfs_emit_options(struct btrfs_fs_info *info,
 {
 	btrfs_info_if_set(info, old, NODATASUM, "setting nodatasum");
 	btrfs_info_if_set(info, old, DEGRADED, "allowing degraded mounts");
-	btrfs_info_if_set(info, old, NODATASUM, "setting nodatasum");
+	btrfs_info_if_set(info, old, NODATACOW, "setting nodatacow");
 	btrfs_info_if_set(info, old, SSD, "enabling ssd optimizations");
 	btrfs_info_if_set(info, old, SSD_SPREAD, "using spread ssd allocation scheme");
 	btrfs_info_if_set(info, old, NOBARRIER, "turning off barriers");
@@ -1452,6 +1452,7 @@ static void btrfs_emit_options(struct btrfs_fs_info *info,
 	btrfs_info_if_set(info, old, IGNOREMETACSUMS, "ignoring meta csums");
 	btrfs_info_if_set(info, old, IGNORESUPERFLAGS, "ignoring unknown super block flags");
 
+	btrfs_info_if_unset(info, old, NODATASUM, "setting datasum");
 	btrfs_info_if_unset(info, old, NODATACOW, "setting datacow");
 	btrfs_info_if_unset(info, old, SSD, "not using ssd optimizations");
 	btrfs_info_if_unset(info, old, SSD_SPREAD, "not using spread ssd allocation scheme");


### PR DESCRIPTION
```
btrfs: restore mount option info messages during mount

    After the fsconfig migration, mount option info messages are no longer
    displayed during mount operations because btrfs_emit_options() is only
    called during remount, not during initial mount.

    Fix this by calling btrfs_emit_options() in btrfs_fill_super() after
    open_ctree() succeeds. Additionally, prevent log duplication by ensuring
    btrfs_check_options() handles validation with warn-level and err-level
    messages, while btrfs_emit_options() provides info-level messages.

    Fixes: eddb1a433f26 ("btrfs: add reconfigure callback for fs_context")
```

```
btrfs: Align log messages and fix duplicates for
    NODATACOW/NODATASUM

    Fix duplicate log messages and make them the same as the log output
    messages related to NODATACOW and NODATASUM, which are output with the
    same logic.

    Fixes: eddb1a433f26 ("btrfs: add reconfigure callback for fs_context")
```